### PR TITLE
Required doc changes and rebranding for 5.0.2 release

### DIFF
--- a/docs-book/master_middleman/source/index.html.md.erb
+++ b/docs-book/master_middleman/source/index.html.md.erb
@@ -7,7 +7,7 @@
       <li class="panel span3">
         <a class="configure" href="hazelcast/index.html" id="service-docs">
           <div class="prodname">
-            Hazelcast IMDG Enterprise <br />for VMware Tanzu
+            Hazelcast Platform Enterprise <br />for VMware Tanzu
           </div>
         </a>
       </li>

--- a/docs-book/master_middleman/source/subnavs/hazelcast_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/hazelcast_subnav.erb
@@ -5,19 +5,19 @@
   <div class="nav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/hazelcast/index.html">Hazelcast IMDG Enterprise for VMware Tanzu</a>
+        <a id='home-nav-link' href="/hazelcast/index.html">Hazelcast Platform Enterprise for VMware Tanzu</a>
       </li>
 
       <li>
-        <a href="/hazelcast/installing.html">Installing and Configuring Hazelcast IMDG Enterprise for VMware Tanzu</a>
+        <a href="/hazelcast/installing.html">Installing and Configuring Hazelcast Platform Enterprise for VMware Tanzu</a>
       </li>
 
       <li>
-        <a href="/hazelcast/using.html">Using Hazelcast IMDG Enterprise for VMware Tanzu</a>
+        <a href="/hazelcast/using.html">Using Hazelcast Platform Enterprise for VMware Tanzu</a>
       </li>
 
       <li>
-        <a href="/hazelcast/release-notes.html">Release Notes for Hazelcast IMDG Enterprise for VMware Tanzu</a>
+        <a href="/hazelcast/release-notes.html">Release Notes for Hazelcast Platform Enterprise for VMware Tanzu</a>
       </li>
 
     </ul>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,28 +1,29 @@
 ---
-title: Hazelcast IMDG Enterprise for VMware Tanzu
+title: Hazelcast Platform Enterprise for VMware Tanzu
 owner: Partners
 ---
 
-This documentation describes how to install, configure, and use Hazelcast IMDG Enterprise for VMware Tanzu. Hazelcast IMDG Enterprise for VMware Tanzu registers a service broker on VMware Tanzu and exposes its service plans on the Marketplace. Developers can provision Hazelcast clusters by creating instances of the service plans using the Cloud Foundry Command Line Interface (cf CLI).
+This documentation describes how to install, configure, and use Hazelcast Platform Enterprise for VMware Tanzu. Hazelcast Platform Enterprise for VMware Tanzu registers a service broker on VMware Tanzu and exposes its service plans on the Marketplace. Developers can provision Hazelcast clusters by creating instances of the service plans using the Cloud Foundry Command Line Interface (cf CLI).
 
 
 ## <a id='overview'></a> Overview
 
-Hazelcast IMDG Enterprise for VMware Tanzu uses an on-demand services SDK, which is a part of [Pivotal Cloud Services SDK](https://network.pivotal.io/products/on-demand-services-sdk), to fully utilize BOSH v2 features and let you provision instances more flexibly.
+Hazelcast Platform Enterprise for VMware Tanzu uses an on-demand services SDK, which is a part of [Pivotal Cloud Services SDK](https://network.pivotal.io/products/on-demand-services-sdk), to fully utilize BOSH v2 features and let you provision instances more flexibly.
 
-Features of Hazelcast IMDG Enterprise for VMware Tanzu include the following:
+Features of Hazelcast Platform Enterprise for VMware Tanzu include the following:
 
-* Based on [Hazelcast IMDG Enterprise](https://hazelcast.com/), the leading in-memory data grid (IMDG)
+* Based on [Hazelcast Platform Enterprise](https://hazelcast.com/), the leading in-memory data grid (IMDG)
 * The ability to dynamically pass your Hazelcast configuration in JSON format when creating services
 * An on-demand service broker that dynamically creates and scales Hazelcast clusters without pre-provisioning blocks of VMs
 
 
 ## <a id="snapshot"></a> Product Snapshot
 
-The following table provides version and version-support information about Hazelcast IMDG Enterprise for VMware Tanzu:
+The following table provides version and version-support information about Hazelcast Platform Enterprise for VMware Tanzu:
 
 <table class="nice">
     <th>Element</th>
+    <th>v5.0</th>
     <th>v4.2</th>
     <th>v4.1</th>
     <th>v4.1</th>
@@ -46,6 +47,7 @@ The following table provides version and version-support information about Hazel
     <th>v1.5</th>
     <tr>
         <td>Version</td>
+        <td>v5.0.2</td>
         <td>v4.2.4</td>
         <td>v4.1.2</td>
         <td>v4.1.1-migration</td>
@@ -71,6 +73,7 @@ The following table provides version and version-support information about Hazel
     </tr>
     <tr>
         <td>Release date</td>
+        <td>January 20, 2022</td>
         <td>December 22, 2021</td>
         <td>April 15, 2021</td>
         <td>April 14, 2021</td>
@@ -96,6 +99,7 @@ The following table provides version and version-support information about Hazel
     </tr>
     <tr>
         <td>Software component version</td>
+        <td>v5.0.2</td>
         <td>v4.2.4</td>
         <td>v4.1.2</td>
         <td>v4.1.1-migration</td>
@@ -122,6 +126,7 @@ The following table provides version and version-support information about Hazel
     <tr>
         <td>Compatible Ops Manager version(s)</td>
         <td>v2.7, v2.8, v2.9, v2.10, v2.11 and v2.12</td>
+        <td>v2.7, v2.8, v2.9, v2.10, v2.11 and v2.12</td>
         <td>v2.6, v2.7, v2.8, v2.9, v2.10 and v2.11</td>
         <td>v2.6, v2.7, v2.8, v2.9 and v2.10</td>
         <td>v2.6, v2.7, v2.8, v2.9 and v2.10</td>
@@ -146,6 +151,7 @@ The following table provides version and version-support information about Hazel
     </tr>
     <tr>
         <td>Compatible Tanzu Application Services (TAS) version(s)</td>
+        <td>v2.7, v2.8, v2.9, v2.10, v2.11 and v2.12</td>
         <td>v2.7, v2.8, v2.9, v2.10, v2.11 and v2.12</td>
         <td>v2.6, v2.7, v2.8, v2.9, v2.10 and v2.11</td>
         <td>v2.6, v2.7, v2.8, v2.9 and v2.10</td>
@@ -190,10 +196,12 @@ The following table provides version and version-support information about Hazel
        <td>Ubuntu Xenial</td>
        <td>Ubuntu Xenial</td>
        <td>Ubuntu Xenial</td>
+       <td>Ubuntu Xenial</td>
        <td>Ubuntu Trusty</td>
     </tr>
     <tr>
         <td>IaaS support</td>
+        <td><a href="https://docs.pivotal.io/pivotalcf/2-0/refarch/index.html">All Reference Architectures</a></td>
         <td><a href="https://docs.pivotal.io/pivotalcf/2-0/refarch/index.html">All Reference Architectures</a></td>
         <td><a href="https://docs.pivotal.io/pivotalcf/2-0/refarch/index.html">All Reference Architectures</a></td>
         <td><a href="https://docs.pivotal.io/pivotalcf/2-0/refarch/index.html">All Reference Architectures</a></td>
@@ -241,6 +249,7 @@ The following table provides version and version-support information about Hazel
         <td>Yes</td>
         <td>Yes</td>
         <td>Yes</td>
+        <td>Yes</td>
     </tr>
 </table>
 
@@ -251,4 +260,4 @@ Please provide any bugs, feature requests, or questions to the [Hazelcast User G
 
 ## <a id='license'></a> License
 
-Hazelcast IMDG Enterprise for VMware Tanzu needs an active Hazelcast IMDG Enterprise License. You can request a trial license from [hazelcast.com](https://hazelcast.com/hazelcast-enterprise-download/trial/) or by contacting [sales@hazelcast.com](mailto:sales@hazelcast.com).
+Hazelcast Platform Enterprise for VMware Tanzu needs an active Hazelcast Platform Enterprise License. You can request a trial license from [hazelcast.com](https://hazelcast.com/hazelcast-enterprise-download/trial/) or by contacting [sales@hazelcast.com](mailto:sales@hazelcast.com).

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Installing and Configuring Hazelcast IMDG Enterprise for VMware Tanzu
+title: Installing and Configuring Hazelcast Platform Enterprise for VMware Tanzu
 owner: Partners
 ---
 
-This topic describes how to install and configure Hazelcast IMDG Enterprise for VMware Tanzu.
+This topic describes how to install and configure Hazelcast Platform Enterprise for VMware Tanzu.
 
-Complete the following steps to download and install the Hazelcast IMDG Enterprise for VMware Tanzu tile on Ops Manager.
+Complete the following steps to download and install the Hazelcast Platform Enterprise for VMware Tanzu tile on Ops Manager.
 
 1. Download the product file from [VMware Tanzu Network](https://network.pivotal.io/products/hazelcast).
 
 1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file.
 
-1. Click **Add** next to the uploaded Hazelcast IMDG Enterprise for VMware Tanzu tile in the Ops Manager **Available Products** view to add it to your staging area.
+1. Click **Add** next to the uploaded Hazelcast Platform Enterprise for VMware Tanzu tile in the Ops Manager **Available Products** view to add it to your staging area.
 
-1. Click the newly added **Hazelcast IMDG Enterprise for VMware Tanzu** tile.
+1. Click the newly added **Hazelcast Platform Enterprise for VMware Tanzu** tile.
 
     <%= image_tag("tile.png") %>
 
@@ -26,9 +26,9 @@ Complete the following steps to download and install the Hazelcast IMDG Enterpri
 1. Click **First On-demand plan**. In the **Hazelcast on-demand plan** pane, do the following:
     1. Enter a **Plan name**.
     1. Enter a **Plan description**.
-    For an example of how the plan name and description appear on the command line, see [Step 1](using.html#marketplace) in the _Using Hazelcast IMDG Enterprise for VMware Tanzu_ topic.
+    For an example of how the plan name and description appear on the command line, see [Step 1](using.html#marketplace) in the _Using Hazelcast Platform Enterprise for VMware Tanzu_ topic.
 
-1. Specify the number of **Hazelcast instances** for this plan. This property defines the number of Hazelcast instances to be created. It can be overridden for each service instance when creating a service instance by using `instanceCount` parameter. See [Step 2](using.html#create-service) in the _Using Hazelcast IMDG Enterprise for VMware Tanzu_ topic for more information.
+1. Specify the number of **Hazelcast instances** for this plan. This property defines the number of Hazelcast instances to be created. It can be overridden for each service instance when creating a service instance by using `instanceCount` parameter. See [Step 2](using.html#create-service) in the _Using Hazelcast Platform Enterprise for VMware Tanzu_ topic for more information.
 
 1. Select a **Hazelcast VM type**. Choose a suitable VM type according to your data size and processing power requirements.
 
@@ -43,12 +43,12 @@ Complete the following steps to download and install the Hazelcast IMDG Enterpri
 1. Click **Save**.
     <%= image_tag("first_plan.png") %>
 
-1. If you want to modify the additional Hazelcast IMDG Enterprise for VMware Tanzu plans, repeat the step above to configure the second and third on-demand plans.
+1. If you want to modify the additional Hazelcast Platform Enterprise for VMware Tanzu plans, repeat the step above to configure the second and third on-demand plans.
 
 1. Click **Errands** and ensure that both **Register on-demand broker** and **Deregister on-demand broker** are selected. These are necessary to create and destroy Hazelcast service instances. You can disable **smoke-tests** errand to decrease installation time.
     <%= image_tag("errands.png") %>
 
-1. Click **Resource Config** and review the IaaS resources used by the Hazelcast IMDG Enterprise for VMware Tanzu components. Do not modify these default settings.
+1. Click **Resource Config** and review the IaaS resources used by the Hazelcast Platform Enterprise for VMware Tanzu components. Do not modify these default settings.
     <%= image_tag("resource_config.png") %>
 
-1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to complete the installation of Hazelcast IMDG Enterprise for VMware Tanzu.
+1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to complete the installation of Hazelcast Platform Enterprise for VMware Tanzu.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,7 +1,15 @@
 ---
-title: Hazelcast IMDG Enterprise for VMware Tanzu Release Notes
+title: Hazelcast Platform Enterprise for VMware Tanzu Release Notes
 owner: Partners
 ---
+
+### v5.0.2
+
+**Release Date:** January 20, 2022
+
+**New in this release**
+
+* Upgrades Hazelcast Platform Enterprise to 5.0.2 and Management Center to 5.0.4
 
 ### v4.2.4
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,17 +1,17 @@
 ---
-title: Using Hazelcast IMDG Enterprise for VMware Tanzu
+title: Using Hazelcast Platform Enterprise for VMware Tanzu
 owner: Partners
 ---
 
-This topic describes how developers use Hazelcast IMDG Enterprise for VMware Tanzu.
+This topic describes how developers use Hazelcast Platform Enterprise for VMware Tanzu.
 
-After your VMware Tanzu operator installs the Hazelcast IMDG Enterprise for VMware Tanzu tile, it automatically registers itself to the Marketplace.
+After your VMware Tanzu operator installs the Hazelcast Platform Enterprise for VMware Tanzu tile, it automatically registers itself to the Marketplace.
 
-Follow these steps to create an instance of the Hazelcast service based on an available plan and bind it to your app. The plans available to you are determined by your VMware Tanzu operator. For more information about configuring plans, see [Installing and Configuring Hazelcast IMDG Enterprise for VMware Tanzu](installing.html).
+Follow these steps to create an instance of the Hazelcast service based on an available plan and bind it to your app. The plans available to you are determined by your VMware Tanzu operator. For more information about configuring plans, see [Installing and Configuring Hazelcast Platform Enterprise for VMware Tanzu](installing.html).
 
 ## <a id="marketplace"></a> Checking Availability
 
-1. To check availability of Hazelcast IMDG Enterprise for VMware Tanzu, run the following command:
+1. To check availability of Hazelcast Platform Enterprise for VMware Tanzu, run the following command:
 
     <pre class="terminal">
 $ cf marketplace
@@ -26,7 +26,7 @@ hazelcast       small, medium, large    Hazelcast Service
 1. Create a file named `hazelcast.json` using this [sample Hazelcast JSON file](https://github.com/hazelcast/hazelcast-code-samples/blob/master/hazelcast-integration/pcf-integration/hazelcast.json) as a template.
 
     <p class="note"><strong> Note:</strong>
-     Hazelcast IMDG Enterprise for VMware Tanzu v1.8.0
+     Hazelcast Platform Enterprise for VMware Tanzu v1.8.0
      and later require JSON config file that uses new structure.
      For more information about JSON config structure, see <a href="#json-config">JSON Config Structure</a> below.
     </p>
@@ -65,11 +65,11 @@ $ cf bind-service myapp hz-cluster
 $ cf restage myapp
     </pre>
 
-1. Start using the Hazelcast IMDG Enterprise. Necessary parameters are passed to your application in `VCAP_SERVICES` environment variable. See [this sample Hazelcast Spring Boot application](https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/pcf-integration) for further information.
+1. Start using the Hazelcast Platform Enterprise. Necessary parameters are passed to your application in `VCAP_SERVICES` environment variable. See [this sample Hazelcast Spring Boot application](https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/pcf-integration) for further information.
 
 
 ### <a id='json-config'></a> JSON Config Structure
-Hazelcast IMDG Enterprise 3.12 comes with `YAML 1.2` configuration [support](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-declaratively-yaml), `YAML 1.2` has a `JSON` support as well. It gives an opportunity to use native JSON configuration support at tile side accordingly.
+Hazelcast Platform Enterprise 3.12 comes with `YAML 1.2` configuration [support](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-declaratively-yaml), `YAML 1.2` has a `JSON` support as well. It gives an opportunity to use native JSON configuration support at tile side accordingly.
 
 The JSON structure consists of two section/JSONs, `hazelcast-pcf` section contains tile specific parameters, `hazelcast` section is derived from Hazelcast YAML file:
 
@@ -296,7 +296,7 @@ The following snippet contains the relevant parts of json configuration for enab
 
 Hazelcast provides integration with OpenSSL, which can provide significant performance improvements. For more information, see [the official Hazelcast OpenSSL integration documentation](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-hazelcast-for-openssl).
 
-The OpenSSL libraries and supporting artifacts are already included with Hazelcast IMDG Enterprise for VMware Tanzu. To enable the OpenSSL integration the configuration, you must include `"factoryClassName": "com.hazelcast.nio.ssl.OpenSSLEngineFactory"` in the `sslConfig`, as in the example below.
+The OpenSSL libraries and supporting artifacts are already included with Hazelcast Platform Enterprise for VMware Tanzu. To enable the OpenSSL integration the configuration, you must include `"factoryClassName": "com.hazelcast.nio.ssl.OpenSSLEngineFactory"` in the `sslConfig`, as in the example below.
 
 ```
 {
@@ -402,3 +402,36 @@ $ cf update-service my-hazelcast-instance -c my-hazelcast-config.json
 ```
 
 The new configuration will be applied to all members.
+
+### Major release upgrade from 4.x to 5.x: Configuration needed
+
+Hazelcast Platform(5.x) is fully API-compatible with former Hazelcast IMDG 4.x versions.
+Rolling Upgrade between these two major versions is supported without migration cluster requirement.
+
+```
+  {
+    "hazelcast-pcf": {
+      ...
+      "jvmOptions": "-Dhazelcast.cluster.version.auto.upgrade.enabled=true"
+    }
+    "hazelcast": {
+      "license-key": "..."
+      ...
+    }
+  }
+```
+
+#### Starting the Rolling Upgrade procedure
+
+After a successful tile update (e.g. via the Ops Manager), you can trigger a Rolling Update
+for a particular service instance by executing:
+
+```
+$ cf update-service my-hazelcast-instance -c my-hazelcast-config.json
+```
+
+You can monitor the RU live with the below command:
+
+```
+$ watch cf service my-hazelcast-instance
+```


### PR DESCRIPTION
With `5.x`, Hazelcast IMDG Enterprise is rebranded as a Hazelcast Platform Enterprise. `5.0.2` is the first `5.x` tile release so required name changes applied with it.